### PR TITLE
Fix accidental rename of the package from pypylibtiff

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-About pypylibtiff
-=================
+About pylibtiff
+===============
 
 Home: https://github.com/pearu/pylibtiff
 
@@ -286,53 +286,53 @@ Current release info
 
 | Name | Downloads | Version | Platforms |
 | --- | --- | --- | --- |
-| [![Conda Recipe](https://img.shields.io/badge/recipe-pypylibtiff-green.svg)](https://anaconda.org/conda-forge/pypylibtiff) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/pypylibtiff.svg)](https://anaconda.org/conda-forge/pypylibtiff) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/pypylibtiff.svg)](https://anaconda.org/conda-forge/pypylibtiff) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/pypylibtiff.svg)](https://anaconda.org/conda-forge/pypylibtiff) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-pylibtiff-green.svg)](https://anaconda.org/conda-forge/pylibtiff) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/pylibtiff.svg)](https://anaconda.org/conda-forge/pylibtiff) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/pylibtiff.svg)](https://anaconda.org/conda-forge/pylibtiff) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/pylibtiff.svg)](https://anaconda.org/conda-forge/pylibtiff) |
 
-Installing pypylibtiff
-======================
+Installing pylibtiff
+====================
 
-Installing `pypylibtiff` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
+Installing `pylibtiff` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
 
 ```
 conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `pypylibtiff` can be installed with `conda`:
+Once the `conda-forge` channel has been enabled, `pylibtiff` can be installed with `conda`:
 
 ```
-conda install pypylibtiff
-```
-
-or with `mamba`:
-
-```
-mamba install pypylibtiff
-```
-
-It is possible to list all of the versions of `pypylibtiff` available on your platform with `conda`:
-
-```
-conda search pypylibtiff --channel conda-forge
+conda install pylibtiff
 ```
 
 or with `mamba`:
 
 ```
-mamba search pypylibtiff --channel conda-forge
+mamba install pylibtiff
+```
+
+It is possible to list all of the versions of `pylibtiff` available on your platform with `conda`:
+
+```
+conda search pylibtiff --channel conda-forge
+```
+
+or with `mamba`:
+
+```
+mamba search pylibtiff --channel conda-forge
 ```
 
 Alternatively, `mamba repoquery` may provide more information:
 
 ```
 # Search all versions available on your platform:
-mamba repoquery search pypylibtiff --channel conda-forge
+mamba repoquery search pylibtiff --channel conda-forge
 
-# List packages depending on `pypylibtiff`:
-mamba repoquery whoneeds pypylibtiff --channel conda-forge
+# List packages depending on `pylibtiff`:
+mamba repoquery whoneeds pylibtiff --channel conda-forge
 
-# List dependencies of `pypylibtiff`:
-mamba repoquery depends pypylibtiff --channel conda-forge
+# List dependencies of `pylibtiff`:
+mamba repoquery depends pylibtiff --channel conda-forge
 ```
 
 
@@ -377,17 +377,17 @@ Terminology
                   produce the finished article (built conda distributions)
 
 
-Updating pypylibtiff-feedstock
-==============================
+Updating pylibtiff-feedstock
+============================
 
-If you would like to improve the pypylibtiff recipe or build a new
+If you would like to improve the pylibtiff recipe or build a new
 package version, please fork this repository and submit a PR. Upon submission,
 your changes will be run on the appropriate platforms to give the reviewer an
 opportunity to confirm that the changes result in a successful build. Once
 merged, the recipe will be re-built and uploaded automatically to the
 `conda-forge` channel, whereupon the built conda packages will be available for
 everybody to install and use from the `conda-forge` channel.
-Note that all branches in the conda-forge/pypylibtiff-feedstock are
+Note that all branches in the conda-forge/pylibtiff-feedstock are
 immediately built and any created packages are uploaded, so PRs should be based
 on branches in forks and branches in the main repository should only be used to
 build distinct package versions.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 52d3e00edbb7aecddabeeb4dff76a6c974b7c90a51a7963ddcefee67453633c4
 
 build:
-  number: 2
+  number: 3
   script:
     - {{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,7 +2,7 @@
 {% set version = "0.5.1" %}
 
 package:
-  name: py{{ name }}
+  name: {{ name }}
   version: {{ version }}
 
 source:


### PR DESCRIPTION
I apparently accidentally renamed the package and there are now `pypylibtiff` packages available for download instead of `pylibtiff`:

https://anaconda.org/conda-forge/pypylibtiff/files?page=1

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
